### PR TITLE
ManaSell: fix Keep/Sell toggle bug, add Kept section, expose price filter

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -2591,6 +2591,10 @@ table {
   --tw-bg-opacity: 1;
   background-color: rgb(209 213 219 / var(--tw-bg-opacity, 1));
 }
+.hover\:bg-gray-50:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(249 250 251 / var(--tw-bg-opacity, 1));
+}
 .hover\:bg-gray-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(55 65 81 / var(--tw-bg-opacity, 1));

--- a/assets/js/manasell/main.js
+++ b/assets/js/manasell/main.js
@@ -14,6 +14,7 @@ class ManaSellApp {
     this.filteredRows = []
     this.omitLowValue = false
     this.priceSortDirection = null // null | 'asc' | 'desc'
+    this.keptSectionExpanded = false
     this.initializeUI()
   }
 
@@ -41,9 +42,8 @@ class ManaSellApp {
     if (omitLowValue) {
       omitLowValue.addEventListener('change', (e) => {
         this.omitLowValue = e.target.checked
-        this.applyOmitLowValue()
-        this.renderTable()
-        this.updateSummary()
+        this.applyAutoKeep()
+        this.applyFilters()
       })
     }
 
@@ -53,10 +53,19 @@ class ManaSellApp {
     const includeFoil = document.getElementById('include-foil')
     const includeNonfoil = document.getElementById('include-nonfoil')
 
-    if (minPrice) minPrice.addEventListener('input', () => this.applyFilters())
-    if (maxPrice) maxPrice.addEventListener('input', () => this.applyFilters())
+    if (minPrice) minPrice.addEventListener('input', () => { this.applyAutoKeep(); this.applyFilters() })
+    if (maxPrice) maxPrice.addEventListener('input', () => { this.applyAutoKeep(); this.applyFilters() })
     if (includeFoil) includeFoil.addEventListener('change', () => this.applyFilters())
     if (includeNonfoil) includeNonfoil.addEventListener('change', () => this.applyFilters())
+
+    // Kept section collapse/expand
+    const keptToggle = document.getElementById('kept-toggle')
+    if (keptToggle) {
+      keptToggle.addEventListener('click', () => {
+        this.keptSectionExpanded = !this.keptSectionExpanded
+        this.updateKeptSectionVisibility()
+      })
+    }
 
     // Bulk actions (only if controls section exists)
     const keepAllFoilsBtn = document.getElementById('keep-all-foils')
@@ -171,8 +180,8 @@ class ManaSellApp {
       return cardRow
     })
 
-    // Show controls (commented out - controls section stays hidden)
-    // document.getElementById('controls-section').classList.remove('hidden')
+    // Show controls
+    document.getElementById('controls-section').classList.remove('hidden')
     document.getElementById('review-section').classList.remove('hidden')
     document.getElementById('export-section').classList.remove('hidden')
 
@@ -190,8 +199,8 @@ class ManaSellApp {
     // Hide progress when done
     this.hideProgress()
 
-    // Re-apply the omit-low-value switch to the freshly loaded rows
-    this.applyOmitLowValue()
+    // Re-apply price/switch auto-keep rules to the freshly loaded rows
+    this.applyAutoKeep()
 
     // Render table
     this.applyFilters()
@@ -231,8 +240,8 @@ class ManaSellApp {
       return cardRow
     })
 
-    // Show controls (commented out - controls section stays hidden)
-    // document.getElementById('controls-section').classList.remove('hidden')
+    // Show controls
+    document.getElementById('controls-section').classList.remove('hidden')
     document.getElementById('review-section').classList.remove('hidden')
     document.getElementById('export-section').classList.remove('hidden')
 
@@ -250,31 +259,43 @@ class ManaSellApp {
     // Hide progress when done
     this.hideProgress()
 
-    // Re-apply the omit-low-value switch to the freshly loaded rows
-    this.applyOmitLowValue()
+    // Re-apply price/switch auto-keep rules to the freshly loaded rows
+    this.applyAutoKeep()
 
     // Render table
     this.applyFilters()
   }
 
-  applyOmitLowValue() {
+  // Recomputes which rows the price controls (the $1 switch and/or the
+  // Min/Max Price fields) should auto-keep. Rows the user has manually
+  // toggled are only overridden the next time this runs, not retroactively.
+  applyAutoKeep() {
+    const minPriceEl = document.getElementById('min-price')
+    const maxPriceEl = document.getElementById('max-price')
+    const minPriceInput = minPriceEl && minPriceEl.value !== '' ? parseFloat(minPriceEl.value) : NaN
+    const maxPriceInput = maxPriceEl && maxPriceEl.value !== '' ? parseFloat(maxPriceEl.value) : NaN
+
+    let effectiveMin = Number.isFinite(minPriceInput) ? minPriceInput : 0
     if (this.omitLowValue) {
-      this.cardRows.forEach(row => {
-        if (row.marketPrice < LOW_VALUE_THRESHOLD && row.keepSellStatus === 'sell') {
+      effectiveMin = Math.max(effectiveMin, LOW_VALUE_THRESHOLD)
+    }
+    const effectiveMax = Number.isFinite(maxPriceInput) ? maxPriceInput : Infinity
+
+    this.cardRows.forEach(row => {
+      const outsideRange = row.marketPrice < effectiveMin || row.marketPrice > effectiveMax
+
+      if (outsideRange) {
+        if (row.keepSellStatus === 'sell') {
           row.keepSellStatus = 'keep'
           row.quantity = 0
           row.autoKept = true
         }
-      })
-    } else {
-      this.cardRows.forEach(row => {
-        if (row.autoKept) {
-          row.keepSellStatus = 'sell'
-          row.quantity = 1
-          row.autoKept = false
-        }
-      })
-    }
+      } else if (row.autoKept) {
+        row.keepSellStatus = 'sell'
+        row.quantity = 1
+        row.autoKept = false
+      }
+    })
   }
 
   togglePriceSort() {
@@ -322,24 +343,16 @@ class ManaSellApp {
   }
 
   applyFilters() {
-    const minPriceEl = document.getElementById('min-price')
-    const maxPriceEl = document.getElementById('max-price')
     const includeFoilEl = document.getElementById('include-foil')
     const includeNonfoilEl = document.getElementById('include-nonfoil')
-    
+
     // Default values if controls section is hidden
-    const minPrice = minPriceEl ? (parseFloat(minPriceEl.value) || 0) : 0
-    const maxPriceInput = maxPriceEl ? maxPriceEl.value : ''
-    const maxPrice = maxPriceInput ? parseFloat(maxPriceInput) : Infinity
     const includeFoil = includeFoilEl ? includeFoilEl.checked : true
     const includeNonfoil = includeNonfoilEl ? includeNonfoilEl.checked : true
 
+    // Price range is handled by applyAutoKeep(), which marks out-of-range
+    // rows as "keep" so they land in the Kept section instead of vanishing.
     this.filteredRows = this.cardRows.filter(row => {
-      // Price filter
-      if (row.marketPrice < minPrice || row.marketPrice > maxPrice) {
-        return false
-      }
-
       // Finish filter
       if (row.finish === 'foil' && !includeFoil) {
         return false
@@ -363,21 +376,42 @@ class ManaSellApp {
   }
 
   renderTable() {
-    const tbody = document.getElementById('review-table-body')
+    const sellRows = this.filteredRows.filter(row => row.keepSellStatus !== 'keep')
+    const keptRows = this.filteredRows.filter(row => row.keepSellStatus === 'keep')
+
+    this.renderRowGroup('review-table-body', sellRows, 'No cards match the current filters')
+    this.renderRowGroup('kept-table-body', keptRows, '')
+
+    const keptSection = document.getElementById('kept-section')
+    const keptCount = document.getElementById('kept-count')
+    if (keptSection) keptSection.classList.toggle('hidden', keptRows.length === 0)
+    if (keptCount) keptCount.textContent = `(${keptRows.length})`
+    this.updateKeptSectionVisibility()
+
+    // Attach event listeners after rendering
+    this.attachQuantityListeners()
+    this.attachKeepSellListeners()
+  }
+
+  renderRowGroup(tbodyId, rows, emptyMessage) {
+    const tbody = document.getElementById(tbodyId)
+    if (!tbody) return
     tbody.innerHTML = ''
 
-    if (this.filteredRows.length === 0) {
-      tbody.innerHTML = `
-        <tr>
-          <td colspan="9" class="px-4 py-8 text-center text-gray-400">
-            No cards match the current filters
-          </td>
-        </tr>
-      `
+    if (rows.length === 0) {
+      if (emptyMessage) {
+        tbody.innerHTML = `
+          <tr>
+            <td colspan="9" class="px-4 py-8 text-center text-gray-400">
+              ${emptyMessage}
+            </td>
+          </tr>
+        `
+      }
       return
     }
 
-    this.filteredRows.forEach(row => {
+    rows.forEach(row => {
       const tr = document.createElement('tr')
       tr.className = 'hover:bg-slate-50'
       if (row.warnings.length > 0) {
@@ -386,13 +420,13 @@ class ManaSellApp {
 
       const status = row.keepSellStatus === 'keep' ? 'keep' : 'sell'
       const statusColor = status === 'keep' ? 'bg-green-100 text-green-800' : 'bg-blue-100 text-blue-800'
-      
+      const escapedId = this.escapeHtml(row.id)
+
       tr.innerHTML = `
         <td class="px-2 py-3">
           <button
-            data-card-id="${row.id}"
+            data-card-id="${escapedId}"
             class="px-2 py-1 text-xs rounded ${statusColor} hover:opacity-80 focus:outline-none focus:ring-2 focus:ring-blue-500"
-            onclick="manasellApp.toggleKeepSell('${row.id}')"
           >
             ${status === 'keep' ? 'Keep' : 'Sell'}
           </button>
@@ -412,7 +446,7 @@ class ManaSellApp {
               min="0"
               max="${row.totalQuantity}"
               value="${row.quantity}"
-              data-card-id="${this.escapeHtml(row.id)}"
+              data-card-id="${escapedId}"
               class="w-16 px-2 py-1 text-sm border border-gray-300 rounded focus:outline-none focus:ring-2 focus:ring-blue-500"
             />
             ${row.quantity < row.totalQuantity ? `<span class="text-xs text-gray-400">/ ${row.totalQuantity}</span>` : ''}
@@ -430,9 +464,13 @@ class ManaSellApp {
       `
       tbody.appendChild(tr)
     })
-    
-    // Attach event listeners after rendering
-    this.attachQuantityListeners()
+  }
+
+  updateKeptSectionVisibility() {
+    const keptContent = document.getElementById('kept-content')
+    const keptChevron = document.getElementById('kept-chevron')
+    if (keptContent) keptContent.classList.toggle('hidden', !this.keptSectionExpanded)
+    if (keptChevron) keptChevron.classList.toggle('rotate-180', this.keptSectionExpanded)
   }
 
   attachQuantityListeners() {
@@ -450,6 +488,15 @@ class ManaSellApp {
       newInput.addEventListener('input', (e) => {
         const cardId = e.target.getAttribute('data-card-id')
         this.updateQuantity(cardId, e.target.value, false) // Don't re-render on input
+      })
+    })
+  }
+
+  attachKeepSellListeners() {
+    const buttons = document.querySelectorAll('button[data-card-id]')
+    buttons.forEach(button => {
+      button.addEventListener('click', () => {
+        this.toggleKeepSell(button.getAttribute('data-card-id'))
       })
     })
   }
@@ -481,6 +528,7 @@ class ManaSellApp {
       return
     }
     
+    const previousStatus = row.keepSellStatus
     const newQty = Math.max(0, Math.min(row.totalQuantity, parseInt(value, 10) || 0))
     row.quantity = newQty
     row.autoKept = false // manual override takes precedence over the switch
@@ -491,7 +539,15 @@ class ManaSellApp {
     } else {
       row.keepSellStatus = 'sell'
     }
-    
+
+    // If the row just crossed the keep/sell boundary, it needs to move
+    // between the Sell table and the Kept section - a full re-render.
+    if (shouldRender && row.keepSellStatus !== previousStatus) {
+      this.renderTable()
+      this.updateSummary()
+      return
+    }
+
     // Update the button status if needed
     if (shouldRender) {
       const button = document.querySelector(`button[data-card-id="${cardId}"]`)
@@ -534,6 +590,7 @@ class ManaSellApp {
       if (row.finish === 'foil') {
         row.keepSellStatus = 'keep'
         row.quantity = 0
+        row.autoKept = false
       }
     })
     this.renderTable()
@@ -564,6 +621,7 @@ class ManaSellApp {
 
       // Keep the first one, sell the rest
       rows.forEach((row, index) => {
+        row.autoKept = false
         if (index === 0) {
           row.keepSellStatus = 'keep'
           row.quantity = 0
@@ -596,6 +654,7 @@ class ManaSellApp {
         // Keep the one with highest quantity (or first if equal)
         rows.sort((a, b) => b.quantity - a.quantity)
         rows.forEach((row, index) => {
+          row.autoKept = false
           if (index === 0) {
             row.keepSellStatus = 'keep'
             row.quantity = 0
@@ -615,6 +674,7 @@ class ManaSellApp {
     this.cardRows.forEach(row => {
       row.keepSellStatus = 'sell'
       row.quantity = 1
+      row.autoKept = false
     })
     this.renderTable()
     this.updateSummary()
@@ -624,6 +684,7 @@ class ManaSellApp {
     this.cardRows.forEach(row => {
       row.keepSellStatus = 'sell'
       row.quantity = 1
+      row.autoKept = false
     })
     this.renderTable()
     this.updateSummary()

--- a/assets/js/manasell/models.js
+++ b/assets/js/manasell/models.js
@@ -4,11 +4,11 @@
 
 export class CardRow {
   constructor(data) {
-    this.id = data.id || this.generateId()
     this.name = data.name || ''
     this.setCode = data.setCode || ''
     this.collectorNumber = data.collectorNumber || ''
     this.finish = data.finish || 'nonfoil' // 'foil' or 'nonfoil'
+    this.id = data.id || this.generateId() // must run after name/setCode/collectorNumber/finish are set
     this.totalQuantity = data.quantity || 1 // Original total quantity from CSV
     this.quantity = data.quantity !== undefined ? (data.keepSellStatus === 'keep' ? 0 : 1) : 1 // Editable sell quantity (defaults to 1)
     this.marketPrice = data.marketPrice || 0

--- a/manasell.html
+++ b/manasell.html
@@ -98,7 +98,7 @@ permalink: /manasell/
     </div>
 
     <!-- Controls Section -->
-    <div id="controls-section" class="hidden bg-white rounded-lg shadow-md p-4 sm:p-6 mb-6" style="display: none !important;">
+    <div id="controls-section" class="hidden bg-white rounded-lg shadow-md p-4 sm:p-6 mb-6">
       <h2 class="text-xl sm:text-2xl font-semibold text-gray-900 mb-4">Controls</h2>
       
       <!-- Price Thresholds -->
@@ -238,6 +238,40 @@ permalink: /manasell/
             <!-- Table rows will be inserted here -->
           </tbody>
         </table>
+      </div>
+
+      <!-- Kept Cards (collapsed by default) -->
+      <div id="kept-section" class="hidden mt-4 border border-gray-200 rounded-lg">
+        <button
+          id="kept-toggle"
+          type="button"
+          class="w-full flex items-center justify-between px-4 py-3 text-sm font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-blue-500 rounded-lg"
+        >
+          <span>Kept (not for sale) <span id="kept-count" class="text-gray-400 font-normal">(0)</span></span>
+          <svg id="kept-chevron" class="w-4 h-4 text-gray-400 transition-transform" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+            <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 9l-7 7-7-7" />
+          </svg>
+        </button>
+        <div id="kept-content" class="hidden overflow-x-auto border-t border-gray-200">
+          <table class="table-fixed w-full border-collapse">
+            <thead>
+              <tr class="bg-slate-50 border-b-2 border-gray-300">
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-20">Keep/Sell</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-48">Card Name</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-32">Set</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-24">Collector #</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-20">Finish</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-24">Quantity</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-24">Price</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-28">Total Value</th>
+                <th class="text-xs uppercase tracking-wide text-slate-500 px-2 py-3 text-left w-32">Warnings</th>
+              </tr>
+            </thead>
+            <tbody id="kept-table-body" class="divide-y divide-gray-200">
+              <!-- Kept rows inserted here -->
+            </tbody>
+          </table>
+        </div>
       </div>
     </div>
 

--- a/manasell.html
+++ b/manasell.html
@@ -8,7 +8,7 @@ permalink: /manasell/
   <div class="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
     <!-- Header -->
     <header class="mb-6 sm:mb-8">
-      <h1 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-2">ManaSell <span class="font-normal text-gray-400">(1.55)</span></h1>
+      <h1 class="text-3xl sm:text-4xl font-bold text-gray-900 mb-2">ManaSell <span class="font-normal text-gray-400">(1.56)</span></h1>
       <p class="text-base sm:text-lg text-gray-600">Convert ManaBox CSV to Card Kingdom Bulk Seller Format</p>
       <div class="mt-4 space-y-2">
         <div class="p-3 sm:p-4 bg-blue-50 border border-blue-200 rounded-lg">


### PR DESCRIPTION
## Summary
- **Root cause of the "Keep button not switching" bug**: `CardRow.generateId()` in `models.js` was called before `name`/`setCode`/`collectorNumber`/`finish` were assigned in the constructor, so every single row got the identical id `undefined-undefined-undefined-undefined`. Clicking Keep/Sell on any row always toggled the first row in the array, not the one you clicked. Fixed by moving id generation after those fields are set.
- Also removed the Keep/Sell button's inline `onclick="...('${row.id}')"` in favor of a proper `addEventListener`, since a card name containing an apostrophe would have broken the generated inline JS string.
- Cards marked Keep now move into a collapsed "Kept (not for sale)" section below the sell table instead of staying inline, with a count badge and expand/collapse toggle.
- Exposed the Controls panel (previously force-hidden) and wired Min/Max Price to actually exclude out-of-range cards from the sell list and the Card Kingdom export CSV — previously those fields only filtered the on-screen table and had no effect on what got exported. The existing "omit under $1" switch now composes with Min/Max Price through one unified pass instead of running its own separate, conflicting logic.

## Test plan
- [x] Verified clicking Keep/Sell on a card with an apostrophe in its name (e.g. Gaea's Cradle) now works via a real DOM click event
- [x] Verified rows move between the Sell table and the collapsed Kept section on both button click and quantity-to-zero edits
- [x] Verified Kept section expand/collapse and count badge
- [x] Verified Min Price and Max Price each correctly auto-exclude out-of-range cards, and that resetting a field restores only the cards it auto-excluded (manual keeps are left alone)
- [x] Verified the Card Kingdom export CSV reflects the price-filtered set, not just the on-screen table
- [x] Verified "Reset All to Sell" (one of the previously-unreachable bulk actions, now exposed) works correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
