### PR TITLE
ManaSell: cache-bust the JS entry point on each build

### DIFF
--- a/manasell.html
+++ b/manasell.html
@@ -303,4 +303,4 @@ permalink: /manasell/
   </div>
 </div>
 
-<script type="module" src="{{ '/assets/js/manasell/main.js' | relative_url }}"></script>
+<script type="module" src="{{ '/assets/js/manasell/main.js' | relative_url }}?v={{ site.time | date: '%s' }}"></script>


### PR DESCRIPTION
## Summary
Following up on a bug report ("cards came in pre-filled as Keep and clicking didn't change them, and they didn't move to a new section") right after PR #17 merged and deployed. I re-read the merged code line by line and reproduced the toggle/Kept-section flow fresh — it works correctly, so I couldn't find an actual code bug to fix.

What I did find: `assets/js/manasell/main.js` is served by GitHub Pages with `cache-control: max-age=600` (10 minutes). If a browser loaded the ManaSell page shortly before a deploy finished, it can keep running the previous script for up to 10 minutes afterward — which would look exactly like "the fix isn't working" (still hitting the old duplicate-card-id bug from before PR #17). The deploy for PR #17 finished only a few minutes before this bug report came in, so the timing lines up.

This PR appends the Jekyll build timestamp as a query string on the `<script>` tag, so every deploy forces browsers to fetch main.js fresh instead of serving a stale cached copy.

## Test plan
- [x] Verified locally that the versioned script URL (`main.js?v=<timestamp>`) still loads and initializes `window.manasellApp` correctly
- [ ] If the original bug report reproduces again after a hard refresh, it's a real remaining bug, not caching — worth confirming with a hard refresh (Cmd+Shift+R) or private window before/after this ships

🤖 Generated with [Claude Code](https://claude.com/claude-code)
