### PR TITLE
ManaSell: fall back to nonfoil price when Scryfall lacks foil USD data

### DIFF
--- a/assets/js/manasell/scryfallEnricher.js
+++ b/assets/js/manasell/scryfallEnricher.js
@@ -70,8 +70,10 @@ export class ScryfallEnricher {
         return cardRow
       }
 
+      const priceInfo = this.getMarketPriceInfo(card, cardRow.finish)
       const enrichment = {
-        marketPrice: this.getMarketPrice(card, cardRow.finish),
+        marketPrice: priceInfo.price,
+        priceIsEstimate: priceInfo.isEstimate,
         setName: card.set_name || '',
         ckEdition: this.mapToCardKingdomEdition(card),
         resolvedSetCode: (card.set || '').toLowerCase(),
@@ -172,13 +174,29 @@ export class ScryfallEnricher {
   }
 
   /**
-   * Get market price for a card based on finish
+   * Get market price for a card based on finish.
+   * Foil USD pricing is often missing on Scryfall for newer or precon-only
+   * foils even when the card itself has a real foil printing (e.g. Modern
+   * Horizons 3 Commander foils). Fall back to the etched price, then to
+   * the nonfoil price as a rough estimate, rather than reporting $0.
    */
-  getMarketPrice(card, finish) {
+  getMarketPriceInfo(card, finish) {
     if (finish === 'foil') {
-      return card.prices?.usd_foil ? parseFloat(card.prices.usd_foil) : 0
-    } else {
-      return card.prices?.usd ? parseFloat(card.prices.usd) : 0
+      if (card.prices?.usd_foil) {
+        return { price: parseFloat(card.prices.usd_foil), isEstimate: false }
+      }
+      if (card.prices?.usd_etched) {
+        return { price: parseFloat(card.prices.usd_etched), isEstimate: false }
+      }
+      if (card.prices?.usd) {
+        return { price: parseFloat(card.prices.usd), isEstimate: true }
+      }
+      return { price: 0, isEstimate: false }
+    }
+
+    return {
+      price: card.prices?.usd ? parseFloat(card.prices.usd) : 0,
+      isEstimate: false
     }
   }
 
@@ -248,6 +266,8 @@ export class ScryfallEnricher {
 
     if (cardRow.marketPrice === 0) {
       cardRow.addWarning('No price data available')
+    } else if (enrichment.priceIsEstimate) {
+      cardRow.addWarning('Foil price estimated from nonfoil (no foil price on Scryfall)')
     }
 
     return cardRow


### PR DESCRIPTION
## Summary
You reported a lot of cards coming back "not found on Scryfall." The concrete example (Akroma's Will, M3C 165, foil) showed the actual warning was **"No price data available,"** not "Card not found" — enrichment was succeeding fine, but Scryfall's `usd_foil` price field is null for a lot of newer or precon-only foils even when a real foil printing exists:

```
"prices": { "usd": "15.15", "usd_foil": null, "usd_etched": null, ... }
```

`getMarketPrice` only ever checked `usd_foil` for foil cards and hard-coded `$0` when it was missing, which is presumably what's showing up broadly across your Modern Horizons 3 Commander (and similar) foils.

## Fix
`getMarketPriceInfo` now falls back, in order: `usd_foil` → `usd_etched` → nonfoil `usd` (flagged as an estimate). When the nonfoil fallback is used, the card gets a distinct warning ("Foil price estimated from nonfoil...") instead of the generic "No price data available," so it's clear the number is an estimate rather than a real foil quote. Genuinely-missing cards are unaffected and still show "Card not found in Scryfall."

## Test plan
- [x] Akroma's Will (M3C 165, foil) — now shows an estimated price with a clear warning instead of $0.00
- [x] A genuinely nonexistent card — still correctly shows "Card not found in Scryfall"
- [x] A normal card with real foil pricing (Lightning Bolt) — unaffected, no spurious warning
- [x] A nonfoil-only card requested as foil (Prismatic Piper, CMM 1) — correctly estimates from its nonfoil price

🤖 Generated with [Claude Code](https://claude.com/claude-code)
